### PR TITLE
Fix void-function error by making use of cl-function

### DIFF
--- a/btc-ticker.el
+++ b/btc-ticker.el
@@ -69,14 +69,13 @@
             (add-to-list 'mode-line-modes '(t btc-ticker-mode-line) t)))))
 
 (defun btc-ticker-fetch()
-  (progn
-    (request
-     bitstamp-api-url
-     :parser 'json-read
-     :success (function*
-               (lambda(&key data &allow-other-keys)
-		 (setq btc-ticker-mode-line
-		       (concat " $" (assoc-default 'last data))))))))
+  (request
+    bitstamp-api-url
+    :parser 'json-read
+    :success (cl-function
+              (lambda(&key data &allow-other-keys)
+                (setq btc-ticker-mode-line
+                      (concat " $" (assoc-default 'last data)))))))
 
 ;;;###autoload
 (define-minor-mode btc-ticker-mode


### PR DESCRIPTION
Enabling `btc-ticker-mode` in Emacs 27.1 gives the following error:

> Error running timer ‘btc-ticker-fetch’: (void-function function*)

Replacing function* with cl-function fixes the issue.